### PR TITLE
Add ESP-IDF packaging for PCAL95555

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # HF-PCAL95555-ESPIDF
-PCAL95555 component for the ESP-IDF
+
+This repository packages the [HF-PCAL95555](https://github.com/N3b3x/HF-PCAL95555) driver as a reusable ESP-IDF component for the ESP32‑C6.  The upstream project provides a hardware‑agnostic C++ implementation of the NXP PCAL95555A GPIO expander.  Here it is arranged in the layout expected by the ESP‑IDF build system and exposes Kconfig options for common settings such as the default I²C address and per‑pin configuration.
+
+## Getting Started
+1. Clone this repository with submodules:
+   ```bash
+   git clone --recursive https://github.com/<your fork>/HF-PCAL95555-ESPIDF
+   ```
+2. Place it inside your application's `components/` directory or add its path via the `EXTRA_COMPONENT_DIRS` CMake variable.
+3. Run `idf.py menuconfig` and configure **PCAL95555 GPIO expander** options under *Component config*.
+4. Implement the `PACL95555::i2cBus` interface using the ESP‑IDF I2C APIs and instantiate `PACL95555` with the configured address.
+
+Refer to `HF-PCAL95555/examples/esp32/main.cpp` for a minimal usage example.
+
+## Component Layout
+```
+components/
+  pcal95555/
+    src/               # Driver source files
+    Kconfig            # Configuration options imported from upstream
+    CMakeLists.txt     # Component build instructions
+    idf_component.yml  # Metadata for the component manager
+```
+The `src` directory is identical to the upstream driver and contains `pacl95555.hpp` and `pcal95555.cpp`.
+
+## License
+This component and the included HF-PCAL95555 driver are distributed under the terms of the GNU GPL v3. See the `LICENSE` file for details.

--- a/components/pcal95555/CMakeLists.txt
+++ b/components/pcal95555/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "src/pcal95555.cpp"
+    INCLUDE_DIRS "src"
+    REQUIRES driver
+)

--- a/components/pcal95555/Kconfig
+++ b/components/pcal95555/Kconfig
@@ -1,0 +1,290 @@
+# Kconfig for PCAL95555 GPIO expander
+menuconfig PCAL95555
+    bool "PCAL95555 GPIO expander"
+    default y
+    help
+      Enable support for the NXP PCAL95555 16-bit I/O expander.
+      When enabled, the driver library can be built and configured
+      with the options below.
+
+if PCAL95555
+
+menu "General settings"
+
+config PCAL95555_DEFAULT_ADDRESS
+    hex "Default I2C address"
+    default 0x20
+    help
+      I2C slave address of the device. The PCAL95555 allows
+      addresses in the range 0x20-0x27 depending on the A0/A1 pins.
+
+config PCAL95555_INIT_FROM_KCONFIG
+    bool "Enable initFromConfig runtime initialization"
+    default y
+    help
+      When enabled, calling initFromConfig() will apply the
+      configuration values selected here at runtime. Disable to
+      compile the driver with initFromConfig() as a no-op.
+
+endmenu
+
+menu "Port 0"
+
+config PCAL95555_PORT0_OD
+    bool "Open-drain mode"
+    default n
+    help
+      Drive all pins on port 0 in open-drain mode when enabled.
+
+
+menu "Pin 0"
+config PCAL95555_P0_0_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P0_0_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P0_0_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P0_0_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 1"
+config PCAL95555_P0_1_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P0_1_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P0_1_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P0_1_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 2"
+config PCAL95555_P0_2_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P0_2_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P0_2_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P0_2_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 3"
+config PCAL95555_P0_3_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P0_3_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P0_3_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P0_3_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 4"
+config PCAL95555_P0_4_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P0_4_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P0_4_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P0_4_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 5"
+config PCAL95555_P0_5_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P0_5_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P0_5_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P0_5_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 6"
+config PCAL95555_P0_6_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P0_6_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P0_6_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P0_6_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 7"
+config PCAL95555_P0_7_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P0_7_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P0_7_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P0_7_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+endmenu
+
+menu "Port 1"
+
+config PCAL95555_PORT1_OD
+    bool "Open-drain mode"
+    default n
+    help
+      Drive all pins on port 1 in open-drain mode when enabled.
+
+menu "Pin 0"
+config PCAL95555_P1_0_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P1_0_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P1_0_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P1_0_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 1"
+config PCAL95555_P1_1_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P1_1_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P1_1_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P1_1_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 2"
+config PCAL95555_P1_2_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P1_2_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P1_2_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P1_2_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 3"
+config PCAL95555_P1_3_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P1_3_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P1_3_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P1_3_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 4"
+config PCAL95555_P1_4_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P1_4_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P1_4_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P1_4_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 5"
+config PCAL95555_P1_5_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P1_5_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P1_5_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P1_5_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 6"
+config PCAL95555_P1_6_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P1_6_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P1_6_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P1_6_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+
+menu "Pin 7"
+config PCAL95555_P1_7_DIR
+    bool "Input direction"
+    default y
+config PCAL95555_P1_7_PULL
+    bool "Enable pull resistor"
+    default n
+config PCAL95555_P1_7_PULL_UP
+    bool "Use pull-up"
+    default y
+config PCAL95555_P1_7_OUTPUT
+    bool "Initial output high"
+    default n
+endmenu
+endmenu
+
+endif # PCAL95555

--- a/components/pcal95555/README.md
+++ b/components/pcal95555/README.md
@@ -1,0 +1,52 @@
+# PCAL95555 ESP-IDF Component
+
+This component packages the [HF-PCAL95555](https://github.com/N3b3x/HF-PCAL95555) driver as an ESP-IDF component targeting the ESP32-C6.
+
+## Features
+- C++11 driver for the NXP PCAL95555A GPIO expander
+- Integrates with the ESP-IDF build system
+- Configurable via Kconfig (default I2C address, pin defaults, etc.)
+- Uses the ESP-IDF `driver` component for I2C transactions
+
+## Directory Structure
+```
+components/
+  pcal95555/
+    src/        # Driver sources
+    Kconfig     # Configuration options
+    CMakeLists.txt
+    idf_component.yml
+```
+
+The original driver sources are located in `src/`. See the upstream repository for detailed API documentation.
+
+## Usage
+1. Add this repository as a submodule under your project's `components/` directory:
+   ```bash
+   git submodule add https://github.com/<your fork>/HF-PCAL95555-ESPIDF components/pcal95555
+   git submodule update --init --recursive
+   ```
+2. Enable the component in menuconfig under `PCAL95555 GPIO expander`.
+3. Include the header in your code:
+   ```cpp
+   #include "pacl95555.hpp"
+   ```
+4. Implement the `i2cBus` interface using ESP-IDF I2C APIs and create a `PACL95555` instance.
+
+Example snippet:
+```cpp
+class ESP32I2CBus : public PACL95555::i2cBus {
+public:
+    bool write(uint8_t addr, uint8_t reg, const uint8_t *data, size_t len) override {
+        uint8_t buf[1 + len];
+        buf[0] = reg;
+        memcpy(&buf[1], data, len);
+        return i2c_master_write_to_device(I2C_NUM_0, addr, buf, len + 1, pdMS_TO_TICKS(100)) == ESP_OK;
+    }
+    bool read(uint8_t addr, uint8_t reg, uint8_t *data, size_t len) override {
+        return i2c_master_write_read_device(I2C_NUM_0, addr, &reg, 1, data, len, pdMS_TO_TICKS(100)) == ESP_OK;
+    }
+};
+```
+
+For a full example see `HF-PCAL95555/examples/esp32/main.cpp` in the upstream repository.

--- a/components/pcal95555/idf_component.yml
+++ b/components/pcal95555/idf_component.yml
@@ -1,0 +1,7 @@
+version: "0.1.0"
+description: PCAL95555 GPIO expander component
+url: https://github.com/N3b3x/HF-PCAL95555
+targets:
+  - esp32c6
+dependencies:
+  idf: "*"

--- a/components/pcal95555/src/pacl95555.hpp
+++ b/components/pcal95555/src/pacl95555.hpp
@@ -1,0 +1,646 @@
+/**
+ * @file pacl95555.hpp
+ * @brief Driver for the PCAL9555 16-bit I/O expander with I²C interface
+ *
+ * This header provides a comprehensive C++ interface for controlling the PCAL9555/PACL95555AHF
+ * 16-bit I/O expander. The driver handles all register-level operations required to configure and
+ * operate the device including:
+ *   - Setting I/O directions (input/output)
+ *   - Reading and writing pin states
+ *   - Configuring pull-up/pull-down resistors
+ *   - Managing interrupt functionality
+ *   - Setting drive strength and output modes
+ *
+ * The implementation uses an abstract I2C interface that must be provided by the user to
+ * accommodate different hardware platforms and I2C libraries.
+ *
+ * @author Nebiyu Tadesse
+ * @date 2025-05-21
+ * @version 1.0
+ *
+ * @note This driver supports the PCAL9555/PACL95555AHF device with 16 GPIO pins
+ *       divided into two 8-bit ports (PORT_0 and PORT_1).
+ */
+#pragma once
+#include <cstdint>
+#include <cstddef>
+#include <functional>
+
+#ifndef CONFIG_PCAL95555_INIT_FROM_KCONFIG
+#define CONFIG_PCAL95555_INIT_FROM_KCONFIG 1
+#endif
+#ifndef CONFIG_PCAL95555_PORT0_OD
+#define CONFIG_PCAL95555_PORT0_OD 0
+#endif
+#ifndef CONFIG_PCAL95555_PORT1_OD
+#define CONFIG_PCAL95555_PORT1_OD 0
+#endif
+
+/* Per-pin defaults */
+#ifndef CONFIG_PCAL95555_P0_0_DIR
+#define CONFIG_PCAL95555_P0_0_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_1_DIR
+#define CONFIG_PCAL95555_P0_1_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_2_DIR
+#define CONFIG_PCAL95555_P0_2_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_3_DIR
+#define CONFIG_PCAL95555_P0_3_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_4_DIR
+#define CONFIG_PCAL95555_P0_4_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_5_DIR
+#define CONFIG_PCAL95555_P0_5_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_6_DIR
+#define CONFIG_PCAL95555_P0_6_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_7_DIR
+#define CONFIG_PCAL95555_P0_7_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_0_DIR
+#define CONFIG_PCAL95555_P1_0_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_1_DIR
+#define CONFIG_PCAL95555_P1_1_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_2_DIR
+#define CONFIG_PCAL95555_P1_2_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_3_DIR
+#define CONFIG_PCAL95555_P1_3_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_4_DIR
+#define CONFIG_PCAL95555_P1_4_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_5_DIR
+#define CONFIG_PCAL95555_P1_5_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_6_DIR
+#define CONFIG_PCAL95555_P1_6_DIR 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_7_DIR
+#define CONFIG_PCAL95555_P1_7_DIR 1
+#endif
+
+#ifndef CONFIG_PCAL95555_P0_0_PULL
+#define CONFIG_PCAL95555_P0_0_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_1_PULL
+#define CONFIG_PCAL95555_P0_1_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_2_PULL
+#define CONFIG_PCAL95555_P0_2_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_3_PULL
+#define CONFIG_PCAL95555_P0_3_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_4_PULL
+#define CONFIG_PCAL95555_P0_4_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_5_PULL
+#define CONFIG_PCAL95555_P0_5_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_6_PULL
+#define CONFIG_PCAL95555_P0_6_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_7_PULL
+#define CONFIG_PCAL95555_P0_7_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_0_PULL
+#define CONFIG_PCAL95555_P1_0_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_1_PULL
+#define CONFIG_PCAL95555_P1_1_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_2_PULL
+#define CONFIG_PCAL95555_P1_2_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_3_PULL
+#define CONFIG_PCAL95555_P1_3_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_4_PULL
+#define CONFIG_PCAL95555_P1_4_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_5_PULL
+#define CONFIG_PCAL95555_P1_5_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_6_PULL
+#define CONFIG_PCAL95555_P1_6_PULL 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_7_PULL
+#define CONFIG_PCAL95555_P1_7_PULL 0
+#endif
+
+#ifndef CONFIG_PCAL95555_P0_0_PULL_UP
+#define CONFIG_PCAL95555_P0_0_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_1_PULL_UP
+#define CONFIG_PCAL95555_P0_1_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_2_PULL_UP
+#define CONFIG_PCAL95555_P0_2_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_3_PULL_UP
+#define CONFIG_PCAL95555_P0_3_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_4_PULL_UP
+#define CONFIG_PCAL95555_P0_4_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_5_PULL_UP
+#define CONFIG_PCAL95555_P0_5_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_6_PULL_UP
+#define CONFIG_PCAL95555_P0_6_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P0_7_PULL_UP
+#define CONFIG_PCAL95555_P0_7_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_0_PULL_UP
+#define CONFIG_PCAL95555_P1_0_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_1_PULL_UP
+#define CONFIG_PCAL95555_P1_1_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_2_PULL_UP
+#define CONFIG_PCAL95555_P1_2_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_3_PULL_UP
+#define CONFIG_PCAL95555_P1_3_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_4_PULL_UP
+#define CONFIG_PCAL95555_P1_4_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_5_PULL_UP
+#define CONFIG_PCAL95555_P1_5_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_6_PULL_UP
+#define CONFIG_PCAL95555_P1_6_PULL_UP 1
+#endif
+#ifndef CONFIG_PCAL95555_P1_7_PULL_UP
+#define CONFIG_PCAL95555_P1_7_PULL_UP 1
+#endif
+
+#ifndef CONFIG_PCAL95555_P0_0_OUTPUT
+#define CONFIG_PCAL95555_P0_0_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_1_OUTPUT
+#define CONFIG_PCAL95555_P0_1_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_2_OUTPUT
+#define CONFIG_PCAL95555_P0_2_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_3_OUTPUT
+#define CONFIG_PCAL95555_P0_3_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_4_OUTPUT
+#define CONFIG_PCAL95555_P0_4_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_5_OUTPUT
+#define CONFIG_PCAL95555_P0_5_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_6_OUTPUT
+#define CONFIG_PCAL95555_P0_6_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P0_7_OUTPUT
+#define CONFIG_PCAL95555_P0_7_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_0_OUTPUT
+#define CONFIG_PCAL95555_P1_0_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_1_OUTPUT
+#define CONFIG_PCAL95555_P1_1_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_2_OUTPUT
+#define CONFIG_PCAL95555_P1_2_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_3_OUTPUT
+#define CONFIG_PCAL95555_P1_3_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_4_OUTPUT
+#define CONFIG_PCAL95555_P1_4_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_5_OUTPUT
+#define CONFIG_PCAL95555_P1_5_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_6_OUTPUT
+#define CONFIG_PCAL95555_P1_6_OUTPUT 0
+#endif
+#ifndef CONFIG_PCAL95555_P1_7_OUTPUT
+#define CONFIG_PCAL95555_P1_7_OUTPUT 0
+#endif
+
+/* Derived port-level masks from per-pin options */
+#ifndef CONFIG_PCAL95555_PORT0_DIRECTION
+#define CONFIG_PCAL95555_PORT0_DIRECTION \
+    ((CONFIG_PCAL95555_P0_0_DIR<<0) | (CONFIG_PCAL95555_P0_1_DIR<<1) | \
+     (CONFIG_PCAL95555_P0_2_DIR<<2) | (CONFIG_PCAL95555_P0_3_DIR<<3) | \
+     (CONFIG_PCAL95555_P0_4_DIR<<4) | (CONFIG_PCAL95555_P0_5_DIR<<5) | \
+     (CONFIG_PCAL95555_P0_6_DIR<<6) | (CONFIG_PCAL95555_P0_7_DIR<<7))
+#endif
+#ifndef CONFIG_PCAL95555_PORT1_DIRECTION
+#define CONFIG_PCAL95555_PORT1_DIRECTION \
+    ((CONFIG_PCAL95555_P1_0_DIR<<0) | (CONFIG_PCAL95555_P1_1_DIR<<1) | \
+     (CONFIG_PCAL95555_P1_2_DIR<<2) | (CONFIG_PCAL95555_P1_3_DIR<<3) | \
+     (CONFIG_PCAL95555_P1_4_DIR<<4) | (CONFIG_PCAL95555_P1_5_DIR<<5) | \
+     (CONFIG_PCAL95555_P1_6_DIR<<6) | (CONFIG_PCAL95555_P1_7_DIR<<7))
+#endif
+#ifndef CONFIG_PCAL95555_PORT0_PULL_ENABLE
+#define CONFIG_PCAL95555_PORT0_PULL_ENABLE \
+    ((CONFIG_PCAL95555_P0_0_PULL<<0) | (CONFIG_PCAL95555_P0_1_PULL<<1) | \
+     (CONFIG_PCAL95555_P0_2_PULL<<2) | (CONFIG_PCAL95555_P0_3_PULL<<3) | \
+     (CONFIG_PCAL95555_P0_4_PULL<<4) | (CONFIG_PCAL95555_P0_5_PULL<<5) | \
+     (CONFIG_PCAL95555_P0_6_PULL<<6) | (CONFIG_PCAL95555_P0_7_PULL<<7))
+#endif
+#ifndef CONFIG_PCAL95555_PORT1_PULL_ENABLE
+#define CONFIG_PCAL95555_PORT1_PULL_ENABLE \
+    ((CONFIG_PCAL95555_P1_0_PULL<<0) | (CONFIG_PCAL95555_P1_1_PULL<<1) | \
+     (CONFIG_PCAL95555_P1_2_PULL<<2) | (CONFIG_PCAL95555_P1_3_PULL<<3) | \
+     (CONFIG_PCAL95555_P1_4_PULL<<4) | (CONFIG_PCAL95555_P1_5_PULL<<5) | \
+     (CONFIG_PCAL95555_P1_6_PULL<<6) | (CONFIG_PCAL95555_P1_7_PULL<<7))
+#endif
+#ifndef CONFIG_PCAL95555_PORT0_PULL_UP
+#define CONFIG_PCAL95555_PORT0_PULL_UP \
+    ((CONFIG_PCAL95555_P0_0_PULL_UP<<0) | (CONFIG_PCAL95555_P0_1_PULL_UP<<1) | \
+     (CONFIG_PCAL95555_P0_2_PULL_UP<<2) | (CONFIG_PCAL95555_P0_3_PULL_UP<<3) | \
+     (CONFIG_PCAL95555_P0_4_PULL_UP<<4) | (CONFIG_PCAL95555_P0_5_PULL_UP<<5) | \
+     (CONFIG_PCAL95555_P0_6_PULL_UP<<6) | (CONFIG_PCAL95555_P0_7_PULL_UP<<7))
+#endif
+#ifndef CONFIG_PCAL95555_PORT1_PULL_UP
+#define CONFIG_PCAL95555_PORT1_PULL_UP \
+    ((CONFIG_PCAL95555_P1_0_PULL_UP<<0) | (CONFIG_PCAL95555_P1_1_PULL_UP<<1) | \
+     (CONFIG_PCAL95555_P1_2_PULL_UP<<2) | (CONFIG_PCAL95555_P1_3_PULL_UP<<3) | \
+     (CONFIG_PCAL95555_P1_4_PULL_UP<<4) | (CONFIG_PCAL95555_P1_5_PULL_UP<<5) | \
+     (CONFIG_PCAL95555_P1_6_PULL_UP<<6) | (CONFIG_PCAL95555_P1_7_PULL_UP<<7))
+#endif
+#ifndef CONFIG_PCAL95555_PORT0_OUTPUT
+#define CONFIG_PCAL95555_PORT0_OUTPUT \
+    ((CONFIG_PCAL95555_P0_0_OUTPUT<<0) | (CONFIG_PCAL95555_P0_1_OUTPUT<<1) | \
+     (CONFIG_PCAL95555_P0_2_OUTPUT<<2) | (CONFIG_PCAL95555_P0_3_OUTPUT<<3) | \
+     (CONFIG_PCAL95555_P0_4_OUTPUT<<4) | (CONFIG_PCAL95555_P0_5_OUTPUT<<5) | \
+     (CONFIG_PCAL95555_P0_6_OUTPUT<<6) | (CONFIG_PCAL95555_P0_7_OUTPUT<<7))
+#endif
+#ifndef CONFIG_PCAL95555_PORT1_OUTPUT
+#define CONFIG_PCAL95555_PORT1_OUTPUT \
+    ((CONFIG_PCAL95555_P1_0_OUTPUT<<0) | (CONFIG_PCAL95555_P1_1_OUTPUT<<1) | \
+     (CONFIG_PCAL95555_P1_2_OUTPUT<<2) | (CONFIG_PCAL95555_P1_3_OUTPUT<<3) | \
+     (CONFIG_PCAL95555_P1_4_OUTPUT<<4) | (CONFIG_PCAL95555_P1_5_OUTPUT<<5) | \
+     (CONFIG_PCAL95555_P1_6_OUTPUT<<6) | (CONFIG_PCAL95555_P1_7_OUTPUT<<7))
+#endif
+
+#ifndef CONFIG_PCAL95555_INIT_DIRECTION
+#define CONFIG_PCAL95555_INIT_DIRECTION \
+    ((CONFIG_PCAL95555_PORT1_DIRECTION << 8) | CONFIG_PCAL95555_PORT0_DIRECTION)
+#endif
+#ifndef CONFIG_PCAL95555_INIT_PULL_ENABLE
+#define CONFIG_PCAL95555_INIT_PULL_ENABLE \
+    ((CONFIG_PCAL95555_PORT1_PULL_ENABLE << 8) | CONFIG_PCAL95555_PORT0_PULL_ENABLE)
+#endif
+#ifndef CONFIG_PCAL95555_INIT_PULL_UP
+#define CONFIG_PCAL95555_INIT_PULL_UP \
+    ((CONFIG_PCAL95555_PORT1_PULL_UP << 8) | CONFIG_PCAL95555_PORT0_PULL_UP)
+#endif
+#ifndef CONFIG_PCAL95555_INIT_OUTPUT
+#define CONFIG_PCAL95555_INIT_OUTPUT \
+    ((CONFIG_PCAL95555_PORT1_OUTPUT << 8) | CONFIG_PCAL95555_PORT0_OUTPUT)
+#endif
+#ifndef CONFIG_PCAL95555_INIT_OD_PORT0
+#define CONFIG_PCAL95555_INIT_OD_PORT0 CONFIG_PCAL95555_PORT0_OD
+#endif
+#ifndef CONFIG_PCAL95555_INIT_OD_PORT1
+#define CONFIG_PCAL95555_INIT_OD_PORT1 CONFIG_PCAL95555_PORT1_OD
+#endif
+
+/** PACL95555 register map (all control registers). */
+/**
+ * @namespace PACL95555_REG
+ * @brief Contains register addresses for the PCAL9555 I/O expander chip
+ * 
+ * The PCAL9555 is a 16-bit I/O expander with I²C interface. This namespace defines
+ * the memory-mapped register addresses used to control and interact with the device.
+ * 
+ * Register groups:
+ * - Input/Output registers (0x00-0x03): Read inputs and control outputs
+ * - Configuration registers (0x04-0x07): Configure polarity and port direction
+ * - Drive strength registers (0x40-0x43): Control output drive strength
+ * - Input/Pull registers (0x44-0x49): Configure input latching and pull-up/down resistors
+ * - Interrupt registers (0x4A-0x4D): Manage interrupt functionality
+ * - Output configuration (0x4F): General output configuration
+ * 
+ * Each register controls 8 pins, with PORT_0 typically handling pins 0-7 and PORT_1 handling pins 8-15.
+ */
+namespace PACL95555_REG {
+    enum : uint8_t {
+        INPUT_PORT_0    = 0x00,
+        INPUT_PORT_1    = 0x01,
+        OUTPUT_PORT_0   = 0x02,
+        OUTPUT_PORT_1   = 0x03,
+        POLARITY_INV_0  = 0x04,
+        POLARITY_INV_1  = 0x05,
+        CONFIG_PORT_0   = 0x06,
+        CONFIG_PORT_1   = 0x07,
+        DRIVE_STRENGTH_0= 0x40,
+        DRIVE_STRENGTH_1= 0x41,
+        DRIVE_STRENGTH_2= 0x42,
+        DRIVE_STRENGTH_3= 0x43,
+        INPUT_LATCH_0   = 0x44,
+        INPUT_LATCH_1   = 0x45,
+        PULL_ENABLE_0   = 0x46,
+        PULL_ENABLE_1   = 0x47,
+        PULL_SELECT_0   = 0x48,
+        PULL_SELECT_1   = 0x49,
+        INT_MASK_0      = 0x4A,
+        INT_MASK_1      = 0x4B,
+        INT_STATUS_0    = 0x4C,
+        INT_STATUS_1    = 0x4D,
+        OUTPUT_CONF     = 0x4F
+    };
+}
+
+/** GPIO direction (1=input, 0=output). */
+enum class GPIODir : uint8_t { Input = 1, Output = 0 };
+
+/** Input polarity inversion (0=normal, 1=inverted). */
+enum class Polarity : uint8_t { Normal = 0, Inverted = 1 };
+
+/** Output drive strength levels (00=¼, 11=full). */
+enum class DriveStrength : uint8_t { Level0 = 0, Level1 = 1, Level2 = 2, Level3 = 3 };
+
+/** Output mode (push-pull vs open-drain). */
+enum class OutputMode : uint8_t { PushPull = 0, OpenDrain = 1 };
+
+/** Error conditions reported by the driver. */
+enum class Error : uint16_t {
+    None          = 0,
+    InvalidPin    = 1 << 0,  ///< Provided pin index out of range
+    InvalidMask   = 1 << 1,  ///< Mask contained bits outside 0-15
+    I2CReadFail   = 1 << 2,  ///< An I2C read operation failed
+    I2CWriteFail  = 1 << 3   ///< An I2C write operation failed
+};
+
+inline Error operator|(Error a, Error b) {
+    return static_cast<Error>(static_cast<uint16_t>(a) |
+                              static_cast<uint16_t>(b));
+}
+inline Error operator&(Error a, Error b) {
+    return static_cast<Error>(static_cast<uint16_t>(a) &
+                              static_cast<uint16_t>(b));
+}
+
+/**
+ * @class PACL95555
+ * @brief Driver for the PACL95555AHF / PCAL9555A I²C GPIO expander.
+ */
+class PACL95555 {
+public:
+    /**
+     * @brief Abstract interface for I2C bus operations.
+     *
+     * @details Users must implement this interface to provide low-level I2C
+     * communication for the PACL95555 driver. Provides basic read and write
+     * methods with ACK/NACK feedback.
+     */
+    class i2cBus {
+    public:
+        virtual ~i2cBus() = default;
+        /**
+         * @brief Write bytes to a device register.
+         *
+         * @param addr 7-bit I2C address of the target device.
+         * @param reg Register address to write to.
+         * @param data Pointer to the data buffer containing bytes to send.
+         * @param len Number of bytes to write from the buffer.
+         * @return true if the device acknowledges the transfer; false on NACK or error.
+         */
+        virtual bool write(uint8_t addr, uint8_t reg, const uint8_t *data, size_t len) = 0;
+        /**
+         * @brief Read bytes from a device register.
+         *
+         * @param addr 7-bit I2C address of the target device.
+         * @param reg Register address to read from.
+         * @param data Pointer to the buffer to store received data.
+         * @param len Number of bytes to read into the buffer.
+         * @return true if the read succeeds; false on NACK or error.
+         */
+        virtual bool read(uint8_t addr, uint8_t reg, uint8_t *data, size_t len) = 0;
+    };
+
+    /**
+     * @brief Construct a new PACL95555 driver instance.
+     *
+     * @param bus Pointer to a user-implemented I2C bus interface.
+     * @param address 7-bit I2C address of the PACL95555 device (0x00 to 0x7F).
+     */
+    PACL95555(PACL95555::i2cBus *bus, uint8_t address);
+
+    /**
+     * @brief Configure retry mechanism for I2C transactions.
+     *
+     * @param retries Maximum number of retry attempts on failure.
+     *                Note: setting N will result in N+1 total attempts per transfer.
+     */
+    void setRetries(int retries);
+
+    /**
+     * @brief Retrieve currently latched error flags.
+     *
+     * @return Bitmask composed of @ref Error values.
+     */
+    uint16_t getErrorFlags() const;
+
+    /**
+     * @brief Clear specific error flags.
+     *
+     * @param mask Bitmask of errors to clear (default: all).
+     */
+    void clearErrorFlags(uint16_t mask = 0xFFFF);
+
+    /**
+     * @brief Reset all registers to their power-on default state.
+     *
+     * @details Available registers are set to inputs, pull-ups enabled,
+     * interrupts masked, drive strength set to full, and output mode
+     * configured as push-pull as specified by the datasheet.
+     */
+    void resetToDefault();
+
+    /**
+     * @brief Initialize the device using values from Kconfig.
+     *
+     * @details This writes the configuration registers using the
+     * CONFIG_PCAL95555_INIT_* options defined at compile time.
+     */
+    void initFromConfig();
+
+    /**
+     * @brief Set the direction of a single GPIO pin.
+     *
+     * @param pin Zero-based pin index (0-15).
+     * @param dir Direction enum: Input or Output.
+     * @return true on success; false on I2C failure.
+     */
+    bool setPinDirection(uint16_t pin, GPIODir dir);
+
+    /**
+     * @brief Set the direction for multiple GPIO pins at once.
+     *
+     * @param mask Bitmask where each set bit indicates a pin to configure.
+     * @param dir Common direction for all selected pins.
+     * @return true on success; false if any I2C operation fails.
+     */
+    bool setMultipleDirections(uint16_t mask, GPIODir dir);
+
+    /**
+     * @brief Read the current logical level of a GPIO pin.
+     *
+     * @param pin Zero-based pin index (0-15).
+     * @return true if pin is high; false if pin is low or on read error.
+     */
+    bool readPin(uint16_t pin);
+
+    /**
+     * @brief Write a logical level to a GPIO output pin.
+     *
+     * @param pin Zero-based pin index (0-15).
+     * @param value true to drive high, false to drive low.
+     * @return true if write succeeded; false on I2C failure.
+     */
+    bool writePin(uint16_t pin, bool value);
+    
+    /**
+     * @brief Toggle the output state of a GPIO pin.
+     *
+     * @param pin Zero-based pin index (0-15).
+     * @return true on success; false on I2C failure.
+     */
+    bool togglePin(uint16_t pin);
+
+    /**
+     * @brief Enable or disable the pull-up/pull-down resistor on a pin.
+     *
+     * @param pin Zero-based pin index (0-15).
+     * @param enable true to enable; false to disable.
+     * @return true on success; false on I2C failure.
+     */
+    bool setPullEnable(uint16_t pin, bool enable);
+    /**
+     * @brief Select internal pull-up or pull-down resistor direction.
+     *
+     * @param pin Zero-based pin index (0-15).
+     * @param pullUp true for pull-up; false for pull-down.
+     * @return true on success; false on I2C failure.
+     */
+    bool setPullDirection(uint16_t pin, bool pullUp);
+
+    /**
+     * @brief Configure the output drive strength for a GPIO pin.
+     *
+     * @param pin Zero-based pin index (0-15).
+     * @param level Drive strength level (Level0..Level3).
+     * @return true on success; false on I2C failure.
+     */
+    bool setDriveStrength(uint16_t pin, DriveStrength level);
+
+    /**
+     * @brief Enable or disable interrupts on multiple pins.
+     *
+     * @param mask Bitmask where 0 enables interrupt, 1 disables per pin.
+     * @return true on success; false on I2C failure.
+     */
+    bool configureInterruptMask(uint16_t mask);
+    /**
+     * @brief Retrieve and clear the interrupt status.
+     *
+     * @return 16-bit mask indicating which pins triggered an interrupt.
+     */
+    uint16_t getInterruptStatus();
+
+    /**
+     * @brief Configure per-port output mode (push-pull or open-drain).
+     *
+     * @param port0OpenDrain true for open-drain on port 0.
+     * @param port1OpenDrain true for open-drain on port 1.
+     * @return true on success; false on I2C failure.
+     */
+    bool setOutputMode(bool port0OpenDrain, bool port1OpenDrain);
+
+    /**
+     * @brief Configure input polarity inversion for a single pin.
+     *
+     * @param pin Zero-based pin index (0-15).
+     * @param polarity Polarity::Normal or Polarity::Inverted.
+     * @return true on success; false on I2C failure.
+     */
+    bool setPinPolarity(uint16_t pin, Polarity polarity);
+
+    /**
+     * @brief Configure input polarity for multiple pins.
+     *
+     * @param mask Bitmask selecting pins to configure.
+     * @param polarity Normal or Inverted for all selected pins.
+     * @return true on success; false on any I2C failure.
+     */
+    bool setMultiplePolarities(uint16_t mask, Polarity polarity);
+
+    /**
+     * @brief Enable or disable the input latch for a single pin.
+     *
+     * @param pin Zero-based pin index (0-15).
+     * @param enable true to enable latch; false to disable.
+     * @return true on success; false on I2C failure.
+     */
+    bool enableInputLatch(uint16_t pin, bool enable);
+
+    /**
+     * @brief Enable or disable input latch for multiple pins.
+     *
+     * @param mask Bitmask selecting pins.
+     * @param enable true to enable; false to disable.
+     * @return true on success; false on any I2C failure.
+     */
+    bool enableMultipleInputLatches(uint16_t mask, bool enable);
+
+    /**
+     * @brief Register a callback to be invoked on GPIO interrupts.
+     *
+     * @param cb Function taking a 16-bit status mask for active interrupts.
+     */
+    void setInterruptCallback(std::function<void(uint16_t)> cb);
+    /**
+     * @brief Internal handler to process an interrupt event.
+     *
+     * @details Reads the interrupt status register and invokes the
+     * previously registered callback if set.
+     */
+    void handleInterrupt();
+
+protected:
+    /**
+     * @brief Read a device register with retry logic.
+     *
+     * @param reg Register address to read.
+     * @param value Reference to store the read byte.
+     * @return true if read succeeds; false on failure.
+     */
+    bool readRegister(uint8_t reg, uint8_t &value);
+    /**
+     * @brief Write a single byte to a device register with retry logic.
+     *
+     * @param reg Register address to write.
+     * @param value Byte value to write.
+     * @return true if write succeeds; false on failure.
+     */
+    bool writeRegister(uint8_t reg, uint8_t value);
+
+    i2cBus *i2c_;
+    uint8_t devAddr_;
+    int retries_{1};
+    uint16_t errorFlags_{0};
+    std::function<void(uint16_t)> irqCallback_;
+
+    void setError(Error e);
+    void clearError(Error e);
+};

--- a/components/pcal95555/src/pcal95555.cpp
+++ b/components/pcal95555/src/pcal95555.cpp
@@ -1,0 +1,324 @@
+#include "pacl95555.hpp"
+#include <cstring>
+
+// Constructor: store I2C bus and device address (7-bit)
+PACL95555::PACL95555(PACL95555::i2cBus *bus, uint8_t address)
+    : i2c_(bus), devAddr_(address) {}
+
+// Configure retry count
+void PACL95555::setRetries(int r) {
+    retries_ = r;
+}
+
+// Low-level write with retries
+bool PACL95555::writeRegister(uint8_t reg, uint8_t value) {
+    for(int attempt = 0; attempt <= retries_; ++attempt) {
+        if (i2c_->write(devAddr_, reg, &value, 1)) {
+            clearError(Error::I2CWriteFail);
+            return true;
+        }
+    }
+    setError(Error::I2CWriteFail);
+    return false;
+}
+// Low-level read with retries
+bool PACL95555::readRegister(uint8_t reg, uint8_t &value) {
+    for(int attempt = 0; attempt <= retries_; ++attempt) {
+        if (i2c_->read(devAddr_, reg, &value, 1)) {
+            clearError(Error::I2CReadFail);
+            return true;
+        }
+    }
+    setError(Error::I2CReadFail);
+    return false;
+}
+
+// Reset all registers to defaults as per datasheet.
+void PACL95555::resetToDefault() {
+    // All defaults taken from datasheet tables.
+    writeRegister(PACL95555_REG::OUTPUT_PORT_0, 0xFF);
+    writeRegister(PACL95555_REG::OUTPUT_PORT_1, 0xFF);
+    writeRegister(PACL95555_REG::POLARITY_INV_0, 0x00);
+    writeRegister(PACL95555_REG::POLARITY_INV_1, 0x00);
+    writeRegister(PACL95555_REG::CONFIG_PORT_0, 0xFF);
+    writeRegister(PACL95555_REG::CONFIG_PORT_1, 0xFF);
+    // Drive strength = full (all bits 1)
+    writeRegister(PACL95555_REG::DRIVE_STRENGTH_0, 0xFF);
+    writeRegister(PACL95555_REG::DRIVE_STRENGTH_1, 0xFF);
+    writeRegister(PACL95555_REG::DRIVE_STRENGTH_2, 0xFF);
+    writeRegister(PACL95555_REG::DRIVE_STRENGTH_3, 0xFF);
+    // Latch disabled (default 0x00)
+    writeRegister(PACL95555_REG::INPUT_LATCH_0, 0x00);
+    writeRegister(PACL95555_REG::INPUT_LATCH_1, 0x00);
+    // Pull-up/down enabled (1), pull-up selected (1), interrupt masked (1)
+    writeRegister(PACL95555_REG::PULL_ENABLE_0, 0xFF);
+    writeRegister(PACL95555_REG::PULL_ENABLE_1, 0xFF);
+    writeRegister(PACL95555_REG::PULL_SELECT_0, 0xFF);
+    writeRegister(PACL95555_REG::PULL_SELECT_1, 0xFF);
+    writeRegister(PACL95555_REG::INT_MASK_0, 0xFF);
+    writeRegister(PACL95555_REG::INT_MASK_1, 0xFF);
+    // Output mode = push-pull (0)
+    writeRegister(PACL95555_REG::OUTPUT_CONF, 0x00);
+}
+
+// Initialize using compile-time configuration
+void PACL95555::initFromConfig() {
+#if CONFIG_PCAL95555_INIT_FROM_KCONFIG
+    writeRegister(PACL95555_REG::OUTPUT_PORT_0,
+                  uint8_t(CONFIG_PCAL95555_INIT_OUTPUT & 0xFF));
+    writeRegister(PACL95555_REG::OUTPUT_PORT_1,
+                  uint8_t((CONFIG_PCAL95555_INIT_OUTPUT >> 8) & 0xFF));
+
+    writeRegister(PACL95555_REG::CONFIG_PORT_0,
+                  uint8_t(CONFIG_PCAL95555_INIT_DIRECTION & 0xFF));
+    writeRegister(PACL95555_REG::CONFIG_PORT_1,
+                  uint8_t((CONFIG_PCAL95555_INIT_DIRECTION >> 8) & 0xFF));
+
+    writeRegister(PACL95555_REG::PULL_ENABLE_0,
+                  uint8_t(CONFIG_PCAL95555_INIT_PULL_ENABLE & 0xFF));
+    writeRegister(PACL95555_REG::PULL_ENABLE_1,
+                  uint8_t((CONFIG_PCAL95555_INIT_PULL_ENABLE >> 8) & 0xFF));
+
+    writeRegister(PACL95555_REG::PULL_SELECT_0,
+                  uint8_t(CONFIG_PCAL95555_INIT_PULL_UP & 0xFF));
+    writeRegister(PACL95555_REG::PULL_SELECT_1,
+                  uint8_t((CONFIG_PCAL95555_INIT_PULL_UP >> 8) & 0xFF));
+
+    uint8_t od = (CONFIG_PCAL95555_INIT_OD_PORT1 ? 1 : 0) << 1 |
+                 (CONFIG_PCAL95555_INIT_OD_PORT0 ? 1 : 0);
+    writeRegister(PACL95555_REG::OUTPUT_CONF, od);
+#endif
+}
+
+// Set or clear a bit in a register byte
+static uint8_t updateBit(uint8_t regVal, uint8_t bit, bool set) {
+    if(set) return regVal | (1 << bit);
+    else    return regVal & ~(1 << bit);
+}
+
+// Direction configuration
+bool PACL95555::setPinDirection(uint16_t pin, GPIODir dir) {
+    if (pin >= 16) {
+        setError(Error::InvalidPin);
+        return false;
+    }
+    clearError(Error::InvalidPin);
+    uint8_t reg = (pin < 8) ? PACL95555_REG::CONFIG_PORT_0 : PACL95555_REG::CONFIG_PORT_1;
+    uint8_t bit = pin % 8;
+    uint8_t val = 0;
+    if (!readRegister(reg, val)) return false;
+    val = updateBit(val, bit, (dir == GPIODir::Input));
+    return writeRegister(reg, val);
+}
+bool PACL95555::setMultipleDirections(uint16_t mask, GPIODir dir) {
+    clearError(Error::InvalidMask);
+    uint8_t val0 = 0;
+    if (!readRegister(PACL95555_REG::CONFIG_PORT_0, val0)) return false;
+    for (int bit=0; bit<8; ++bit) {
+        if (mask & (1u<<bit)) val0 = updateBit(val0, bit, (dir == GPIODir::Input));
+    }
+    if (!writeRegister(PACL95555_REG::CONFIG_PORT_0, val0)) return false;
+
+    uint8_t val1 = 0;
+    if (!readRegister(PACL95555_REG::CONFIG_PORT_1, val1)) return false;
+    for (int bit=0; bit<8; ++bit) {
+        if (mask & (1u<<(bit+8))) val1 = updateBit(val1, bit, (dir == GPIODir::Input));
+    }
+    return writeRegister(PACL95555_REG::CONFIG_PORT_1, val1);
+}
+
+// Read input port registers and return bit
+bool PACL95555::readPin(uint16_t pin) {
+    if (pin >= 16) {
+        setError(Error::InvalidPin);
+        return false;
+    }
+    clearError(Error::InvalidPin);
+    uint8_t reg = (pin < 8) ? PACL95555_REG::INPUT_PORT_0 : PACL95555_REG::INPUT_PORT_1;
+    uint8_t bit = pin % 8;
+    uint8_t val = 0;
+    if (!readRegister(reg, val)) return false;
+    return (val & (1 << bit)) != 0;
+}
+
+// Write output port registers
+bool PACL95555::writePin(uint16_t pin, bool value) {
+    if (pin >= 16) {
+        setError(Error::InvalidPin);
+        return false;
+    }
+    clearError(Error::InvalidPin);
+    uint8_t reg = (pin < 8) ? PACL95555_REG::OUTPUT_PORT_0 : PACL95555_REG::OUTPUT_PORT_1;
+    uint8_t bit = pin % 8;
+    uint8_t val = 0;
+    if (!readRegister(reg, val)) return false;
+    val = updateBit(val, bit, value);
+    return writeRegister(reg, val);
+}
+
+bool PACL95555::togglePin(uint16_t pin) {
+    if (pin >= 16) {
+        setError(Error::InvalidPin);
+        return false;
+    }
+    clearError(Error::InvalidPin);
+    uint8_t reg = (pin < 8) ? PACL95555_REG::OUTPUT_PORT_0 : PACL95555_REG::OUTPUT_PORT_1;
+    uint8_t bit = pin % 8;
+    uint8_t val = 0;
+    if (!readRegister(reg, val)) return false;
+    val ^= (1 << bit);
+    return writeRegister(reg, val);
+}
+
+// Pull-up/down control
+bool PACL95555::setPullEnable(uint16_t pin, bool enable) {
+    if (pin >= 16) {
+        setError(Error::InvalidPin);
+        return false;
+    }
+    clearError(Error::InvalidPin);
+    uint8_t reg = (pin < 8) ? PACL95555_REG::PULL_ENABLE_0 : PACL95555_REG::PULL_ENABLE_1;
+    uint8_t bit = pin % 8;
+    uint8_t val = 0;
+    if (!readRegister(reg, val)) return false;
+    val = updateBit(val, bit, enable);
+    return writeRegister(reg, val);
+}
+bool PACL95555::setPullDirection(uint16_t pin, bool pullUp) {
+    if (pin >= 16) {
+        setError(Error::InvalidPin);
+        return false;
+    }
+    clearError(Error::InvalidPin);
+    uint8_t reg = (pin < 8) ? PACL95555_REG::PULL_SELECT_0 : PACL95555_REG::PULL_SELECT_1;
+    uint8_t bit = pin % 8;
+    uint8_t val = 0;
+    if (!readRegister(reg, val)) return false;
+    val = updateBit(val, bit, pullUp);
+    return writeRegister(reg, val);
+}
+
+// Drive strength (2 bits per pin)
+bool PACL95555::setDriveStrength(uint16_t pin, DriveStrength level) {
+    if (pin >= 16) {
+        setError(Error::InvalidPin);
+        return false;
+    }
+    clearError(Error::InvalidPin);
+    uint8_t base = (pin < 8) ? PACL95555_REG::DRIVE_STRENGTH_0 : PACL95555_REG::DRIVE_STRENGTH_2;
+    uint8_t index = pin % 8;
+    uint8_t reg = base + ((index >= 4) ? 1 : 0);
+    uint8_t bit = (index % 4) * 2; // each pin uses 2 bits
+    uint8_t val = 0;
+    if (!readRegister(reg, val)) return false;
+    // Clear the two bits and set the new level
+    val &= ~(0x3 << bit);
+    val |= (uint8_t(level) << bit);
+    return writeRegister(reg, val);
+}
+
+// Interrupt mask
+bool PACL95555::configureInterruptMask(uint16_t mask) {
+    if (!writeRegister(PACL95555_REG::INT_MASK_0, uint8_t(mask & 0xFF))) return false;
+    return writeRegister(PACL95555_REG::INT_MASK_1, uint8_t((mask >> 8) & 0xFF));
+}
+
+// Read interrupt status (and clear)
+uint16_t PACL95555::getInterruptStatus() {
+    uint8_t lo=0, hi=0;
+    readRegister(PACL95555_REG::INT_STATUS_0, lo);
+    readRegister(PACL95555_REG::INT_STATUS_1, hi);
+    return uint16_t(hi)<<8 | lo;
+}
+
+// Output mode configuration (ODEN bits)
+bool PACL95555::setOutputMode(bool od0, bool od1) {
+    uint8_t val = (od1?1:0) << 1 | (od0?1:0);
+    return writeRegister(PACL95555_REG::OUTPUT_CONF, val);
+}
+
+// Interrupt callback
+void PACL95555::setInterruptCallback(std::function<void(uint16_t)> cb) {
+    irqCallback_ = cb;
+}
+
+// Call this when an INT occurs; read status and invoke callback.
+void PACL95555::handleInterrupt() {
+    if (irqCallback_) {
+        uint16_t status = getInterruptStatus();
+        irqCallback_(status);
+    }
+}
+
+bool PACL95555::setPinPolarity(uint16_t pin, Polarity polarity) {
+    if (pin >= 16) {
+        setError(Error::InvalidPin);
+        return false;
+    }
+    clearError(Error::InvalidPin);
+    uint8_t reg = (pin < 8) ? PACL95555_REG::POLARITY_INV_0 : PACL95555_REG::POLARITY_INV_1;
+    uint8_t bit = pin % 8;
+    uint8_t val = 0;
+    if (!readRegister(reg, val)) return false;
+    val = updateBit(val, bit, uint8_t(polarity));
+    return writeRegister(reg, val);
+}
+bool PACL95555::setMultiplePolarities(uint16_t mask, Polarity polarity) {
+    uint8_t val0=0;
+    if (!readRegister(PACL95555_REG::POLARITY_INV_0, val0)) return false;
+    for (int bit=0; bit<8; ++bit) {
+        if (mask & (1u<<bit)) val0 = updateBit(val0, bit, uint8_t(polarity));
+    }
+    if (!writeRegister(PACL95555_REG::POLARITY_INV_0, val0)) return false;
+    uint8_t val1=0;
+    if (!readRegister(PACL95555_REG::POLARITY_INV_1, val1)) return false;
+    for (int bit=0; bit<8; ++bit) {
+        if (mask & (1u<<(bit+8))) val1 = updateBit(val1, bit, uint8_t(polarity));
+    }
+    return writeRegister(PACL95555_REG::POLARITY_INV_1, val1);
+}
+
+bool PACL95555::enableInputLatch(uint16_t pin, bool enable) {
+    if (pin >= 16) {
+        setError(Error::InvalidPin);
+        return false;
+    }
+    clearError(Error::InvalidPin);
+    uint8_t reg = (pin < 8) ? PACL95555_REG::INPUT_LATCH_0 : PACL95555_REG::INPUT_LATCH_1;
+    uint8_t bit = pin % 8;
+    uint8_t val = 0;
+    if (!readRegister(reg, val)) return false;
+    val = updateBit(val, bit, enable);
+    return writeRegister(reg, val);
+}
+bool PACL95555::enableMultipleInputLatches(uint16_t mask, bool enable) {
+    clearError(Error::InvalidMask);
+    uint8_t val0=0;
+    if (!readRegister(PACL95555_REG::INPUT_LATCH_0, val0)) return false;
+    for (int bit=0; bit<8; ++bit) {
+        if (mask & (1u<<bit)) val0 = updateBit(val0, bit, enable);
+    }
+    if (!writeRegister(PACL95555_REG::INPUT_LATCH_0, val0)) return false;
+    uint8_t val1=0;
+    if (!readRegister(PACL95555_REG::INPUT_LATCH_1, val1)) return false;
+    for (int bit=0; bit<8; ++bit) {
+        if (mask & (1u<<(bit+8))) val1 = updateBit(val1, bit, enable);
+    }
+    return writeRegister(PACL95555_REG::INPUT_LATCH_1, val1);
+}
+
+uint16_t PACL95555::getErrorFlags() const {
+    return errorFlags_;
+}
+
+void PACL95555::clearErrorFlags(uint16_t mask) {
+    errorFlags_ &= ~mask;
+}
+
+void PACL95555::setError(Error e) {
+    errorFlags_ |= static_cast<uint16_t>(e);
+}
+
+void PACL95555::clearError(Error e) {
+    errorFlags_ &= ~static_cast<uint16_t>(e);
+}

--- a/components/pcal95555/src/pcal95555_test.cpp
+++ b/components/pcal95555/src/pcal95555_test.cpp
@@ -1,0 +1,132 @@
+#include <cassert>
+#include <iostream>
+#include <unordered_map>
+#include "pacl95555.hpp"
+
+// Mock I2C bus that simulates the PCAL9555A device registers and behavior
+class MockI2C : public PACL95555::i2cBus {
+public:
+    MockI2C() {
+        // Initialize all registers to power-on default values:
+        registers[PACL95555_REG::INPUT_PORT_0]  = 0xFF;
+        registers[PACL95555_REG::INPUT_PORT_1]  = 0xFF;
+        registers[PACL95555_REG::OUTPUT_PORT_0] = 0xFF;
+        registers[PACL95555_REG::OUTPUT_PORT_1] = 0xFF;
+        registers[PACL95555_REG::POLARITY_INV_0] = 0x00;
+        registers[PACL95555_REG::POLARITY_INV_1] = 0x00;
+        registers[PACL95555_REG::CONFIG_PORT_0]  = 0xFF;
+        registers[PACL95555_REG::CONFIG_PORT_1]  = 0xFF;
+        registers[PACL95555_REG::DRIVE_STRENGTH_0] = 0xFF;
+        registers[PACL95555_REG::DRIVE_STRENGTH_1] = 0xFF;
+        registers[PACL95555_REG::DRIVE_STRENGTH_2] = 0xFF;
+        registers[PACL95555_REG::DRIVE_STRENGTH_3] = 0xFF;
+        registers[PACL95555_REG::INPUT_LATCH_0] = 0x00;
+        registers[PACL95555_REG::INPUT_LATCH_1] = 0x00;
+        registers[PACL95555_REG::PULL_ENABLE_0] = 0xFF;
+        registers[PACL95555_REG::PULL_ENABLE_1] = 0xFF;
+        registers[PACL95555_REG::PULL_SELECT_0] = 0xFF;
+        registers[PACL95555_REG::PULL_SELECT_1] = 0xFF;
+        registers[PACL95555_REG::INT_MASK_0] = 0xFF;
+        registers[PACL95555_REG::INT_MASK_1] = 0xFF;
+        registers[PACL95555_REG::INT_STATUS_0] = 0x00;
+        registers[PACL95555_REG::INT_STATUS_1] = 0x00;
+        registers[PACL95555_REG::OUTPUT_CONF]  = 0x00;
+    }
+
+    bool write(uint8_t addr, uint8_t reg, const uint8_t *data, size_t len) override {
+        if (failNextWriteCount > 0) {
+            failNextWriteCount--;
+            return false;
+        }
+        for (size_t i = 0; i < len; ++i) {
+            uint8_t regAddr = reg + i;
+            registers[regAddr] = data[i];
+            // Simulate output->input reflection for push-pull/open-drain
+            if (regAddr == PACL95555_REG::OUTPUT_PORT_0 || regAddr == PACL95555_REG::OUTPUT_PORT_1) {
+                bool isPort0 = (regAddr == PACL95555_REG::OUTPUT_PORT_0);
+                uint8_t portBit = isPort0 ? 0 : 1;
+                uint8_t confVal = registers[isPort0 ? PACL95555_REG::CONFIG_PORT_0 : PACL95555_REG::CONFIG_PORT_1];
+                uint8_t outVal  = registers[regAddr];
+                uint8_t modeVal = registers[PACL95555_REG::OUTPUT_CONF];
+                bool openDrain  = (modeVal >> portBit) & 0x1;
+                uint8_t inputReg = isPort0 ? PACL95555_REG::INPUT_PORT_0 : PACL95555_REG::INPUT_PORT_1;
+                uint8_t newInputVal = registers[inputReg];
+                for (int bit = 0; bit < 8; ++bit) {
+                    bool isOutputPin = ((confVal >> bit) & 0x1) == 0;
+                    bool outputLevel = (outVal >> bit) & 0x1;
+                    if (isOutputPin) {
+                        if (openDrain) {
+                            if (outputLevel) newInputVal |= (1 << bit);
+                            else             newInputVal &= ~(1 << bit);
+                        } else {
+                            if (outputLevel) newInputVal |= (1 << bit);
+                            else             newInputVal &= ~(1 << bit);
+                        }
+                    }
+                }
+                registers[inputReg] = newInputVal;
+            }
+        }
+        return true;
+    }
+
+    bool read(uint8_t addr, uint8_t reg, uint8_t *data, size_t len) override {
+        if (failNextReadCount > 0) {
+            failNextReadCount--;
+            return false;
+        }
+        for (size_t i = 0; i < len; ++i) {
+            uint8_t regAddr = reg + i;
+            data[i] = registers.count(regAddr) ? registers[regAddr] : 0;
+            if (regAddr == PACL95555_REG::INT_STATUS_0 || regAddr == PACL95555_REG::INT_STATUS_1)
+                registers[regAddr] = 0x00;
+        }
+        return true;
+    }
+
+    void setNextWriteNack(int count) { failNextWriteCount = count; }
+    void setNextReadNack(int count)  { failNextReadCount = count; }
+    uint8_t getReg(uint8_t regAddr) const {
+        auto it = registers.find(regAddr);
+        return (it != registers.end()) ? it->second : 0;
+    }
+
+private:
+    std::unordered_map<uint8_t, uint8_t> registers;
+    int failNextWriteCount = 0;
+    int failNextReadCount  = 0;
+};
+
+int main() {
+    MockI2C mock;
+    PACL95555 dev(&mock, 0x20);
+
+    // Test resetToDefault()
+    uint8_t tmp = 0x00;
+    mock.write(0x20, PACL95555_REG::CONFIG_PORT_0, &tmp, 1);
+    dev.resetToDefault();
+    assert(mock.getReg(PACL95555_REG::CONFIG_PORT_0) == 0xFF);
+
+    // Test pin direction
+    assert(dev.setPinDirection(3, GPIODir::Output));
+    assert((mock.getReg(PACL95555_REG::CONFIG_PORT_0) & (1 << 3)) == 0);
+
+    // Simulate I2C write failure
+    mock.setNextWriteNack(2); // fail both attempts
+    assert(!dev.setPinDirection(1, GPIODir::Input));
+    assert(dev.getErrorFlags() & static_cast<uint16_t>(Error::I2CWriteFail));
+    // Successful call should clear the error
+    assert(dev.setPinDirection(1, GPIODir::Input));
+    assert((dev.getErrorFlags() & static_cast<uint16_t>(Error::I2CWriteFail)) == 0);
+
+    // Invalid pin test
+    assert(!dev.writePin(20, true));
+    assert(dev.getErrorFlags() & static_cast<uint16_t>(Error::InvalidPin));
+    dev.clearErrorFlags();
+    assert(dev.getErrorFlags() == 0);
+
+    // ...additional tests as detailed earlier...
+
+    std::cout << "All tests passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- package HF-PCAL95555 driver as an ESP-IDF component
- create `idf_component.yml`, `Kconfig`, and `CMakeLists.txt`
- add component README with usage instructions
- expand repository README with packaging details

## Testing
- `g++ -c components/pcal95555/src/pcal95555.cpp -std=c++11 -Icomponents/pcal95555/src`


------
https://chatgpt.com/codex/tasks/task_e_684092fb52ec8328bc4eb21b05933481